### PR TITLE
Add force_recheck input to check_arb workflow

### DIFF
--- a/.github/workflows/check_arb.yml
+++ b/.github/workflows/check_arb.yml
@@ -2,6 +2,12 @@ name: Check ARB
 
 on:
   workflow_dispatch:
+    inputs:
+      force_recheck:
+        description: 'Force recheck all firmwares even if already checked'
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '0 0 * * *' # Run daily
 
@@ -96,6 +102,7 @@ jobs:
 
       - name: Restore ARB Cache
         id: cache-arb
+        if: github.event.inputs.force_recheck != 'true'
         uses: actions/cache/restore@v4
         with:
           path: |


### PR DESCRIPTION
This commit adds a `force_recheck` boolean input to the `workflow_dispatch` trigger in the `check_arb.yml` workflow. When enabled, this input causes the workflow to bypass the `Restore ARB Cache` step, forcing a fresh download and analysis of the firmware. This ensures that the "last checked" date is updated in the README even if the firmware version has not changed.

## Summary by Sourcery

CI:
- Extend the check_arb workflow_dispatch trigger with a boolean force_recheck input that controls whether the ARB cache restore step is skipped on manual runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ability to manually trigger a full recheck of all firmwares via workflow dispatch, with cache behavior adjusted accordingly when force recheck is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->