### PR TITLE
Add 'Last Checked' column to HTML site

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -172,6 +172,7 @@
                                 <th scope="col">Version</th>
                                 <th scope="col">ARB</th>
                                 <th scope="col">Status</th>
+                                <th scope="col">Last Checked</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -195,10 +196,11 @@
                                     <span class="badge badge-warning">Unknown</span>
                                     {% endif %}
                                 </td>
+                                <td>{{ variant.last_checked }}</td>
                             </tr>
                             {% endfor %}
                             {% if not device.variants %}
-                            <tr><td colspan="4" style="text-align:center; padding: 20px;">No data available</td></tr>
+                            <tr><td colspan="5" style="text-align:center; padding: 20px;">No data available</td></tr>
                             {% endif %}
                         </tbody>
                     </table>


### PR DESCRIPTION
This PR adds a "Last Checked" column to the generated HTML site, allowing users to see when each firmware variant was last updated. This involves modifying the `templates/index.html` file to include the new column in the table structure. Verification was performed using a Playwright script to generate a screenshot of the updated table, and existing tests were run to ensure no regressions.

---
*PR created automatically by Jules for task [2147742512130752265](https://jules.google.com/task/2147742512130752265) started by @Bartixxx32*

## Summary by Sourcery

Add a new 'Last Checked' column to the firmware variants table in the generated HTML site to display when each variant was last updated.

New Features:
- Display the 'Last Checked' timestamp for each firmware variant in the HTML index table.

Enhancements:
- Adjust the empty-state table row to span the new column layout when no variants are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Last Checked" column to the device variants table, providing visibility into when each device was last checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->