### PR TITLE
Add website link to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Automated ARB (Anti-Rollback) index tracker for OnePlus devices. This repository monitors firmware updates and tracks ARB changes over time.
 
+**Website:** [https://bartixxx32.github.io/OnePlus-antirollchecker/](https://bartixxx32.github.io/OnePlus-antirollchecker/)
+
 ## 📊 Current Status
 
 ### OnePlus 15

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -108,6 +108,8 @@ def generate_readme(history_data: Dict) -> str:
         '',
         'Automated ARB (Anti-Rollback) index tracker for OnePlus devices. This repository monitors firmware updates and tracks ARB changes over time.',
         '',
+        '**Website:** [https://bartixxx32.github.io/OnePlus-antirollchecker/](https://bartixxx32.github.io/OnePlus-antirollchecker/)',
+        '',
         '## 📊 Current Status',
         ''
     ]


### PR DESCRIPTION
Added a link to the project website (https://bartixxx32.github.io/OnePlus-antirollchecker/) to the generated README.md. Modified `generate_readme.py` to include this link in the generation process and regenerated the `README.md`. Also added a `.gitignore` file to prevent committing `__pycache__` files.

---
*PR created automatically by Jules for task [12646901512739787410](https://jules.google.com/task/12646901512739787410) started by @Bartixxx32*

## Summary by Sourcery

Add the project website link to the README and its generator, and ignore Python bytecode cache directories.

Documentation:
- Add a link to the hosted project website in the README and generated README content.

Chores:
- Introduce a .gitignore entry to exclude __pycache__ directories from version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added website link to project documentation.

* **Chores**
  * Updated build artifacts and cache file exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->