### PR TITLE
Use rglob to find firmware images in subdirectories

### DIFF
--- a/analyze_firmware.py
+++ b/analyze_firmware.py
@@ -48,7 +48,8 @@ def analyze_firmware(zip_path, tools_dir, output_dir):
         
     # 2. Find extracted image
     # pattern: matches anything with xbl_config inside extracted folder
-    img_files = list(output_dir.glob("*xbl_config*.img"))
+    # Use rglob to search recursively because otaripper creates a subdirectory
+    img_files = list(output_dir.rglob("*xbl_config*.img"))
     if not img_files:
         logger.error("xbl_config image not found in extraction output")
         return None


### PR DESCRIPTION
Updated `analyze_firmware.py` to use `rglob` instead of `glob` when searching for `xbl_config` images. This ensures the script correctly finds images when `otaripper` creates nested subdirectories for extracted content. Validated with a reproduction test case and existing regression tests.

---
*PR created automatically by Jules for task [12834164930929139343](https://jules.google.com/task/12834164930929139343) started by @Bartixxx32*

## Summary by Sourcery

Bug Fixes:
- Ensure xbl_config firmware images are found when extraction tools place them in nested subdirectories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware image detection to locate files in subdirectories, ensuring comprehensive analysis of firmware packages that may be organized in nested directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->