### PR TITLE
Fix India model name and added history

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,11 +503,11 @@ Automated ARB (Anti-Rollback) index tracker for OnePlus devices. This repository
 </details>
 
 <details>
-<summary>📜 <b> India History</b> (click to expand)</summary>
+<summary>📜 <b>India History</b> (click to expand)</summary>
 
 | Firmware Version | ARB | OEM Version | Last Seen | Safe |
 |:---|:---|:---|:---|:---|
-| CPH2707_16.0.1.300(EX01) | 0 | Major: 3, Minor: 0 | 2026-02-06 | ✅ |
+| CPH2707_16.0.1.300(EX01) | 0 | Major: 3, Minor: 0 | 2026-02-04 | ✅ |
 
 </details>
 


### PR DESCRIPTION
## Summary by Sourcery

Correct India device variant information and extend regional firmware history documentation for the OnePlus CPH270x lineup.

Documentation:
- Fix the India variant model identifier in the regional firmware table.
- Add an expandable history section documenting India firmware versions for the device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OnePlus Nord 5 India entry to reflect the corrected model designation while preserving firmware and verification metadata.
  * Added a new India History subsection with a recent firmware record (Last Seen 2026-02-04) and an expanded India firmware history details block.
  * Minor formatting and end-of-file timestamp adjustments for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->