### PR TITLE
Fix Telegram notification and clean up history update logic

### DIFF
--- a/.github/workflows/check_arb.yml
+++ b/.github/workflows/check_arb.yml
@@ -88,6 +88,9 @@ jobs:
     needs: [setup-matrix, prepare-tools]
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.BOTTOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -291,9 +294,6 @@ jobs:
       
       - name: Send Telegram Notification
         if: steps.update_history.outputs.is_new == 'true' && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.BOTTOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           # Extract ARB from result.json (it is always created by previous steps if we are here)
           ARB=$(python3 -c "import sys, json; print(json.load(open('result.json')).get('arb_index', 'Unknown'))")

--- a/simulate_workflow.py
+++ b/simulate_workflow.py
@@ -88,17 +88,16 @@ def main():
     # Patch requests in fetch_firmware module to return our mocked data
     with patch('fetch_firmware.requests.get') as mock_get:
         # We need to simulate the response structure expected by get_from_oos_api
-        mock_resp_url = MagicMock()
-        mock_resp_url.status_code = 200
-        mock_resp_url.text = mock_url
-        mock_resp_url.raise_for_status = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "download_url": mock_url,
+            "version_number": mock_version,
+            "md5sum": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+        mock_resp.raise_for_status = MagicMock()
 
-        mock_resp_ver = MagicMock()
-        mock_resp_ver.status_code = 200
-        mock_resp_ver.text = mock_version
-        mock_resp_ver.raise_for_status = MagicMock()
-
-        mock_get.side_effect = [mock_resp_url, mock_resp_ver]
+        mock_get.return_value = mock_resp
 
         fetched_info = fetch_firmware.get_from_oos_api(target_device, target_variant)
 

--- a/update_history.py
+++ b/update_history.py
@@ -116,8 +116,6 @@ def main():
             version = data.get('version') or version
             arb = int(data.get('arb_index') if data.get('arb_index') is not None else data.get('arb'))
             major = int(data.get('major', 0))
-            arb = int(data.get('arb_index') if data.get('arb_index') is not None else data.get('arb'))
-            major = int(data.get('major', 0))
             minor = int(data.get('minor', 0))
             if not args.md5 and data.get('md5'):
                 args.md5 = data.get('md5')


### PR DESCRIPTION
This PR fixes an issue where Telegram notifications were being skipped in the `check_arb` workflow. In GitHub Actions, step-level `env` variables are not available during the evaluation of the step's `if` condition. By moving these variables to the job level, the condition `env.TELEGRAM_BOT_TOKEN != ''` now evaluates correctly.

Additionally:
- Redundant assignments in `update_history.py` were removed.
- `simulate_workflow.py` was updated to correctly mock the OOS API response structure, ensuring local simulations are accurate.

---
*PR created automatically by Jules for task [9802342190771535635](https://jules.google.com/task/9802342190771535635) started by @Bartixxx32*

## Summary by Sourcery

Fix Telegram notification triggering in the check_arb workflow and align local simulation and history update logic with the expected data structures.

Bug Fixes:
- Ensure Telegram notifications run by exposing bot token and chat ID at the job level so the conditional check evaluates correctly.
- Correct simulate_workflow to mock the OOS API response using the expected JSON structure, keeping local runs consistent with production behavior.
- Remove redundant assignments in update_history to avoid unnecessary re-processing of ARB and version metadata.

Enhancements:
- Simplify history update handling by cleaning up duplicate ARB and major version assignments in update_history.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to streamline environment variable management for notifications

* **Tests**
  * Refactored API test mocking structure for improved code organization

* **Refactor**
  * Removed redundant variable assignments in JSON data processing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->