### PR TITLE
Add force_recheck option to historical backfill workflow

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -10,6 +10,11 @@ on:
       variant:
         description: 'Target Variant (optional, e.g. CN)'
         required: false
+      force_recheck:
+        description: 'Force recheck all firmwares'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}
@@ -147,6 +152,7 @@ jobs:
 
       - name: Cache ARB Data
         id: cache-arb
+        if: github.event.inputs.force_recheck != 'true'
         uses: actions/cache@v4
         with:
           path: firmware_data/


### PR DESCRIPTION
This change adds a `force_recheck` boolean option to the Historical Backfill workflow trigger. When enabled, it bypasses the ARB data cache, forcing a fresh download and analysis of the firmware, matching the functionality already present in the main ARB check workflow.

---
*PR created automatically by Jules for task [3311259103528459051](https://jules.google.com/task/3311259103528459051) started by @Bartixxx32*

## Summary by Sourcery

Add an optional force_recheck input to the historical backfill workflow to allow bypassing cached ARB firmware data when desired.

New Features:
- Introduce a force_recheck boolean input parameter to the historical backfill GitHub Actions workflow trigger.

Enhancements:
- Conditionally skip the ARB data cache step when force_recheck is enabled to force fresh firmware download and analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backfill workflow with a new `force_recheck` input parameter that allows skipping cached data when needed during backfill operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->