### PR TITLE
Add OnePlus 13s support

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ class DeviceMeta(TypedDict):
 DEVICE_ORDER = [
     # Flagships (New)
     "15", "15R", 
-    "13", "13R", "13T",
+    "13", "13R", "13T", "13s",
     "Open",
     "12", "12R", 
     "11", "11R", 
@@ -101,6 +101,12 @@ DEVICE_METADATA: Dict[str, DeviceMeta] = {
         "name": "OnePlus 13T",
         "models": {
             "CN": "PKX110"
+        },
+    },
+    "13s": {
+        "name": "OnePlus 13s",
+        "models": {
+            "IN": "CPH2723"
         },
     },
     "12": {
@@ -472,6 +478,7 @@ SPRING_MAPPING = {
     "oneplus_13": "OP 13",
     "oneplus_13r": "OP 13R",
     "oneplus_13t": "OP 13T",
+    "oneplus_13s": "OP 13S",
     "oneplus_12": "OP 12",
     "oneplus_12r": "OP ACE 3",
     "oneplus_ace_6t": "OP ACE 6T",
@@ -514,6 +521,7 @@ OOS_MAPPING = {
     "13": "oneplus_13",
     "13R": "oneplus_13r",
     "13T": "oneplus_13t",
+    "13s": "oneplus_13s",
     "12": "oneplus_12",
     "12R": "oneplus_12r",
     "11": "oneplus_11",


### PR DESCRIPTION
This change adds support for the OnePlus 13s (specifically the India model CPH2723) to the firmware checker.

Key changes:
- Updated `config.py` to include "13s" in the flagship device order.
- Added metadata for "OnePlus 13s" with model "CPH2723" and region "IN".
- Configured API mappings for both OOS and Springer APIs to enable automated firmware fetching.

Verification:
- Confirmed that `fetch_firmware.py 13s IN --json` successfully retrieves the latest firmware version (CPH2723_16.0.3.501(EX01)) and download URL.
- Visually verified the frontend appearance using a temporary site generation preview.

---
*PR created automatically by Jules for task [2805162830705161523](https://jules.google.com/task/2805162830705161523) started by @Bartixxx32*

## Summary by Sourcery

Add OnePlus 13s (India CPH2723) as a supported flagship device in the firmware tooling and mappings.

New Features:
- Support the OnePlus 13s device as a first-class flagship in the firmware checker, including India region model CPH2723.

Enhancements:
- Extend device ordering and internal identifier mappings to include OnePlus 13s across configuration and API mapping tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OnePlus 13s device variant, including regional model mappings for enhanced device compatibility across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->