### PR TITLE
Update payload-dumper-go credits to reflect fallback role

### DIFF
--- a/generate_readme.py
+++ b/generate_readme.py
@@ -255,7 +255,7 @@ def generate_readme(history_data: Dict) -> str:
         '## Credits',
         '',
         '- **Payload Extraction**: [otaripper](https://github.com/syedinsaf/otaripper) by syedinsaf',
-        '- **Playback & Validation**: [payload-dumper-go](https://github.com/ssut/payload-dumper-go) by ssut',
+        '- **Payload Extraction (Fallback)**: [payload-dumper-go](https://github.com/ssut/payload-dumper-go) by ssut',
         '- **ARB Extraction**: [arbextract](https://github.com/koaaN/arbextract) by koaaN',
         '- **API for CN variants**: [roms.danielspringer.at](https://roms.danielspringer.at/) by Daniel Springer',
         '- **Firmware API**: [Oxygen Updater](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater)',

--- a/templates/index.html
+++ b/templates/index.html
@@ -869,7 +869,7 @@
                 Payload Extraction by <a href="https://github.com/syedinsaf/otaripper" target="_blank">otaripper</a>
                 (syedinsaf)
                 &bull;
-                Validation by <a href="https://github.com/ssut/payload-dumper-go" target="_blank">payload-dumper-go</a>
+                Extraction Fallback by <a href="https://github.com/ssut/payload-dumper-go" target="_blank">payload-dumper-go</a>
                 (ssut)
                 &bull;
                 ARB Extraction by <a href="https://github.com/koaaN/arbextract" target="_blank">arbextract</a> (koaaN)


### PR DESCRIPTION
Updated the credits section in `generate_readme.py` and the footer in `templates/index.html` to more accurately describe `payload-dumper-go` as an extraction fallback rather than "Playback & Validation". Verified by running generation scripts and checking output.

---
*PR created automatically by Jules for task [3509561635766885913](https://jules.google.com/task/3509561635766885913) started by @Bartixxx32*

## Summary by Sourcery

Clarify how payload-dumper-go is credited across generated documentation and the web UI footer.

Enhancements:
- Adjust web UI footer copy to label payload-dumper-go as an extraction fallback to better reflect its role.

Documentation:
- Update README credits to describe payload-dumper-go as a payload extraction fallback rather than a playback/validation tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credit attributions for `payload-dumper-go` to reflect "Extraction Fallback" in both the credits section and footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->