### PR TITLE
Rename Oxygen Updater to OS Updater in credits and bot

### DIFF
--- a/bot/bot_listener.py
+++ b/bot/bot_listener.py
@@ -17,7 +17,7 @@ GITHUB_TOKEN = os.environ.get("GITHUB_PAT")
 GITHUB_REPO = "Bartixxx32/OnePlus-antirollchecker"
 WORKFLOW_ID = "telegram_check.yml"
 ADMIN_USER_ID = 277390840  # Bartixxx32's Telegram user ID
-BOT_VERSION = "1.1.3"
+BOT_VERSION = "1.1.4"
 BOT_START_TIME = time.time()
 
 # Paths
@@ -268,7 +268,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "ℹ️ /about — Bot info, version & uptime\n"
         "❓ /help — Show this message\n\n"
         "*How /download works:*\n"
-        "1. Bot resolves device name → fetches firmware URL from Oxygen Updater API\n"
+        "1. Bot resolves device name → fetches firmware URL from OS Updater API\n"
         "2. Triggers ARB analysis via GitHub Actions\n"
         "3. Posts download link + ARB results as replies\n\n"
         "📋 _Rate limit: 2 checks per minute_"
@@ -314,7 +314,7 @@ async def about(update: Update, context: ContextTypes.DEFAULT_TYPE):
         f"🔢 *Total checks:* {data.get('total_checks', 0)}\n\n"
         f"🔗 [GitHub Repository](https://github.com/{GITHUB_REPO})\n"
         f"💬 [Support Group](https://t.me/oneplusarbchecker)\n"
-        f"🌐 [OOS Downloader API](https://oosdownloader-gui.fly.dev/) (Powered by [Oxygen Updater](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater))\n\n"
+        f"🌐 [OOS Downloader API](https://oosdownloader-gui.fly.dev/) (Powered by [OS Updater](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater))\n\n"
         f"_Made with ❤️ by @Bartixxx32_"
     )
     await update.message.reply_text(msg, parse_mode="Markdown", disable_web_page_preview=True)

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -250,7 +250,7 @@ def generate_readme(history_data: Dict) -> str:
         '',
         '🌐 **API Endpoint**: [https://oosdownloader-gui.fly.dev/](https://oosdownloader-gui.fly.dev/)',
         '',
-        'Our OOS Downloader API provides direct, signed download URLs for OnePlus OTA firmware files by leveraging the [Oxygen Updater API](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater).',
+        'Our OOS Downloader API provides direct, signed download URLs for OnePlus OTA firmware files by leveraging the [OS Updater API](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater).',
         '',
         '---',
         ''
@@ -263,7 +263,7 @@ def generate_readme(history_data: Dict) -> str:
         '- **Payload Extraction (Fallback)**: [payload-dumper-go](https://github.com/ssut/payload-dumper-go) by ssut',
         '- **ARB Extraction**: [arbextract](https://github.com/koaaN/arbextract) by koaaN',
         '- **API for CN variants**: [roms.danielspringer.at](https://roms.danielspringer.at/) by Daniel Springer',
-        '- **Firmware API**: [Oxygen Updater](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater)',
+        '- **Firmware API**: [OS Updater](https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater)',
         '',
         '---',
         '',

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@
             </div>
             <div class="footer-card">
                 <h3 style="color: var(--accent);">🌐 OOS Downloader API</h3>
-                <p>Get direct, signed download URLs for OnePlus OTA firmware files by leveraging the <a href="https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater" target="_blank">Oxygen Updater API</a>.</p>
+                <p>Get direct, signed download URLs for OnePlus OTA firmware files by leveraging the <a href="https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater" target="_blank">OS Updater API</a>.</p>
                 <p><a href="https://oosdownloader-gui.fly.dev/" target="_blank">oosdownloader-gui.fly.dev</a></p>
             </div>
             <div class="footer-card" style="text-align:center;">
@@ -149,7 +149,7 @@
                 CN API by <a href="https://roms.danielspringer.at/" target="_blank">roms.danielspringer.at</a> (Daniel
                 Springer)
                 &bull;
-                API powered by <a href="https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater" target="_blank">Oxygen Updater</a>
+                API powered by <a href="https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater" target="_blank">OS Updater</a>
             </p>
             <p style="margin-top:6px;" id="last-scan">Last scan: Loading...</p>
         </div>


### PR DESCRIPTION
Update credits on the website, README generator, and Telegram bot to reflect the new name "OS Updater". Incremented bot version to 1.1.4.

---
*PR created automatically by Jules for task [12119656030129546718](https://jules.google.com/task/12119656030129546718) started by @Bartixxx32*

## Summary by Sourcery

Enhancements:
- Update user-facing references from Oxygen Updater to OS Updater in bot help/about texts, README generator content, and website footer credits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.4.
  * Updated branding references from "Oxygen Updater" to "OS Updater" across help text, about messages, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->