### PR TITLE
OnePlus Nord CE 3: Correct the Model Number

### DIFF
--- a/config.py
+++ b/config.py
@@ -359,7 +359,7 @@ DEVICE_METADATA: Dict[str, DeviceMeta] = {
     "Nord CE 3": {
         "name": "OnePlus Nord CE 3",
         "models": {
-            "IN": "CPH2567"
+            "IN": "CPH2569"
         },
     },
     "Nord CE 2 Lite": {


### PR DESCRIPTION
The Previous Model Number "CPH2567" corresponded to another phone. The Correct Model Number for Nord CE 3 is "CPH2569"

## Summary by Sourcery

Bug Fixes:
- Update the OnePlus Nord CE 3 India variant model number from CPH2567 to the correct CPH2569 value in the device configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device configuration for Nord CE 3 (India region model).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->