### PR TITLE
fix: correct Nord CE 3 India model number to CPH2569

### DIFF
--- a/config.py
+++ b/config.py
@@ -359,7 +359,7 @@ DEVICE_METADATA: Dict[str, DeviceMeta] = {
     "Nord CE 3": {
         "name": "OnePlus Nord CE 3",
         "models": {
-            "IN": "CPH2567"
+            "IN": "CPH2569"
         },
     },
     "Nord CE 2 Lite": {

--- a/data/history/Nord CE 3_IN.json
+++ b/data/history/Nord CE 3_IN.json
@@ -34,5 +34,5 @@
   "device": "OnePlus Nord CE 3",
   "device_id": "Nord CE 3",
   "region": "IN",
-  "model": "CPH2567"
+  "model": "CPH2569"
 }


### PR DESCRIPTION
Corrected the model number for OnePlus Nord CE 3 (India region) from CPH2567 to CPH2569 in config.py and data/history/Nord CE 3_IN.json. Verified the fix by regenerating the database and README, and performing visual verification via Playwright to ensure the correct model number is displayed on the website.

---
*PR created automatically by Jules for task [6472706165532455054](https://jules.google.com/task/6472706165532455054) started by @Bartixxx32*

## Summary by Sourcery

Bug Fixes:
- Fix the Nord CE 3 (India) model identifier from CPH2567 to CPH2569 in configuration and history data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device model identifier for Nord CE 3 in the Indian region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->