### PR TITLE
Add OnePlus Turbo 6 (PLU110) and Turbo 6V (PLY110) support

### DIFF
--- a/config.py
+++ b/config.py
@@ -72,10 +72,11 @@ DEVICE_ORDER = [
     "Nord N30", "Nord N20",
     "Nord 1", "Nord N200 5G",
     
-    # China Exclusives (Ace)
-    "Ace 6T", 
+    # China Exclusives (Turbo / Ace)
+    "Turbo 6", "Turbo 6V",
+    "Ace 6T",
     "Ace 6",
-    "Ace 5 Pro", "Ace 5", 
+    "Ace 5 Pro", "Ace 5",
     "Ace 3 Pro", "Ace 3V", "Ace 3",
 
     # Pads
@@ -371,7 +372,19 @@ DEVICE_METADATA: Dict[str, DeviceMeta] = {
         },
     },
 
-    # China Exclusives (Ace)
+    # China Exclusives (Turbo / Ace)
+    "Turbo 6": {
+        "name": "OnePlus Turbo 6",
+        "models": {
+            "CN": "PLU110"
+        },
+    },
+    "Turbo 6V": {
+        "name": "OnePlus Turbo 6V",
+        "models": {
+            "CN": "PLY110"
+        },
+    },
     "Ace 6T": {
         "name": "OnePlus Ace 6T",
         "models": {
@@ -543,6 +556,8 @@ SPRING_MAPPING = {
     "oneplus_13s": "OP 13S",
     "oneplus_12": "OP 12",
     "oneplus_12r": "OP ACE 3",
+    "oneplus_turbo_6": "OP TURBO 6",
+    "oneplus_turbo_6v": "OP TURBO 6V",
     "oneplus_ace_6t": "OP ACE 6T",
     "oneplus_ace_6": "OP ACE 6",
     "oneplus_ace_5": "OP ACE 5",
@@ -620,6 +635,9 @@ OOS_MAPPING = {
     "Nord CE 3": "oneplus_nord_ce_3",
     "Nord CE 3 Lite": "oneplus_nord_ce_3_lite",
     "Nord CE 2 Lite": "oneplus_nord_ce_2_lite",
+    # Turbo
+    "Turbo 6": "oneplus_turbo_6",
+    "Turbo 6V": "oneplus_turbo_6v",
     # Ace
     "Ace 6T": "oneplus_ace_6t",
     "Ace 6": "oneplus_ace_6",


### PR DESCRIPTION
## Add OnePlus Turbo 6 series (China)

Registers the China-exclusive **OnePlus Turbo 6** and **Turbo 6V** so their CN ARB history is tracked automatically.

| Device | Model | Springer label |
|---|---|---|
| OnePlus Turbo 6 | `PLU110` | `OP TURBO 6` |
| OnePlus Turbo 6V | `PLY110` | `OP TURBO 6V` |

### Changes (config.py only)
- `DEVICE_ORDER` — added `Turbo 6`, `Turbo 6V` under the China-exclusive section
- `DEVICE_METADATA` — display names + CN model numbers
- `SPRING_MAPPING` — `oneplus_turbo_6` → `OP TURBO 6`, `oneplus_turbo_6v` → `OP TURBO 6V`
- `OOS_MAPPING` — device-id → internal-id entries

### Verification
- Confirmed both labels exist in the danielspringer OTA catalog (CN region).
- `tests/test_config.py` passes locally: **24 passed**.
- Cross-checked ARB on a real **Turbo 6 (PLU110)** unit: `16.0.8.300(CN01)` and `16.0.9.401(CN01)` both report **vbmeta rollback_index = 0** (parsed from the extracted `vbmeta`), matching the tracker's expected "safe" state — so the automated checks should populate cleanly.

No data/history files touched — those are generated by CI on the next run.

## Summary by Sourcery

Add configuration and mappings to support tracking ARB history for the China-exclusive OnePlus Turbo 6 and Turbo 6V devices.

New Features:
- Register OnePlus Turbo 6 (PLU110) and Turbo 6V (PLY110) as China-exclusive devices in the tracker configuration.

Enhancements:
- Extend Springer and OOS device mappings to include OnePlus Turbo 6 and Turbo 6V identifiers and labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OnePlus Turbo 6 and Turbo 6V devices.
  * Added device identification and firmware/name mappings for both models.
  * Updated the China Exclusives device list to include Turbo 6 and Turbo 6V.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->